### PR TITLE
Ancestor paths

### DIFF
--- a/lib/mongoid/path_extension.rb
+++ b/lib/mongoid/path_extension.rb
@@ -28,6 +28,15 @@ module Mongoid
       components.length > 1
     end
 
+    def ancestor_paths
+      return unless has_parent?
+      res = []
+      components[0..-2].each_with_index do |component, index|
+        res << components[0..index].join('/')
+      end
+      res
+    end
+
     def parent_path
       return unless has_parent?
       components[0..-2].join('/')

--- a/test/mongoid/path_extension_test.rb
+++ b/test/mongoid/path_extension_test.rb
@@ -10,39 +10,39 @@ describe Mongoid::PathExtension do
   subject { PathExtensionTest.new(path: path) }
 
   it 'preserves it' do
-    subject.path.must_equal path
+    _(subject.path).must_equal path
   end
 
   it '#components' do
-    subject.path.components.must_equal %w(LevelOne LevelTwo LevelThree)
+    _(subject.path.components).must_equal %w(LevelOne LevelTwo LevelThree)
   end
 
   it '#absolute' do
-    subject.path.absolute.must_equal "/#{path}"
+    _(subject.path.absolute).must_equal "/#{path}"
   end
 
   it '#root' do
-    subject.path.root.must_equal 'LevelOne'
+    _(subject.path.root).must_equal 'LevelOne'
   end
 
   it '#permalink' do
-    subject.path.permalink.must_equal 'LevelThree'
+    _(subject.path.permalink).must_equal 'LevelThree'
   end
 
   it '#parent_path' do
-    subject.path.parent_path.must_equal 'LevelOne/LevelTwo'
+    _(subject.path.parent_path).must_equal 'LevelOne/LevelTwo'
   end
 
   it '#parent_permalink' do
-    subject.path.parent_permalink.must_equal 'LevelTwo'
+    _(subject.path.parent_permalink).must_equal 'LevelTwo'
   end
 
   it '#ancestor_paths' do
-    subject.path.ancestor_paths.must_equal %w[LevelOne LevelOne/LevelTwo]
+    _(subject.path.ancestor_paths).must_equal %w[LevelOne LevelOne/LevelTwo]
   end
 
   it '#has_parent?' do
-    Mongoid::PathExtension.new('LevelOne/LevelTwo').has_parent?.must_equal true
-    Mongoid::PathExtension.new('LevelOne').has_parent?.must_equal false
+    _(Mongoid::PathExtension.new('LevelOne/LevelTwo').has_parent?).must_equal true
+    _(Mongoid::PathExtension.new('LevelOne').has_parent?).must_equal false
   end
 end

--- a/test/mongoid/path_extension_test.rb
+++ b/test/mongoid/path_extension_test.rb
@@ -37,6 +37,10 @@ describe Mongoid::PathExtension do
     subject.path.parent_permalink.must_equal 'LevelTwo'
   end
 
+  it '#ancestor_paths' do
+    subject.path.ancestor_paths.must_equal %w[LevelOne LevelOne/LevelTwo]
+  end
+
   it '#has_parent?' do
     Mongoid::PathExtension.new('LevelOne/LevelTwo').has_parent?.must_equal true
     Mongoid::PathExtension.new('LevelOne').has_parent?.must_equal false


### PR DESCRIPTION
Adds `#ancestor_paths`, a simple getter which returns an array of the ancestor paths. Also cleans up the test suite, removing the deprecation warnings.